### PR TITLE
Adding a simple setup script.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name = 'filltex',
+      version = '1.1',
+      description = 'A LaTeX reference tool',
+      long_description = 'A LaTeX reference tool',
+
+      author = 'Davide Gerosa and Michele Vallisneri',
+      author_email = 'dgerosa@caltech.edu',
+      url = 'https://github.com/dgerosa/filltex',
+
+      py_modules = ['fillbib'],
+
+      scripts = ['bin/fillbib','bin/filltex']
+      )


### PR DESCRIPTION
Running `python setup.py install` will install `fillbib.py` in `/usr/local/lib/python2.7/site-packages` (or a similar location) and `filltex` and  `fillbib` in `/usr/local/bin`, or a similar location that should be already on the path for most Python installations.