### PR TITLE
Adapt for upcoming release of new INSPIRE version

### DIFF
--- a/fillbib.py
+++ b/fillbib.py
@@ -42,7 +42,7 @@ def ads_citation(c): # download single ADS citation
 
 def inspire_citation(c): # download single INSPIRE citation
 
-    f= urllib.urlopen("https://inspirehep.net/search?p="+c+"&of=hx&em=B&sf=year&so=d&rg=1")
+    f= urllib.urlopen("https://old.inspirehep.net/search?p="+c+"&of=hx&em=B&sf=year&so=d&rg=1")
     bib = f.read()
     if sys.version_info.major>=3:
         bib=bib.decode()


### PR DESCRIPTION
We will release the new INSPIRE version (currently at https://labs.inspirehep.net) as the main website on Monday. The old website will remain available at https://old.inspirehep.net for a couple of months. The new API is not 100% ready for public use, so this commit simply switches to the URL of the old website instead of using the new one.