### PR TITLE
Allows search by eprint in fillbib.py

### DIFF
--- a/fillbib.py
+++ b/fillbib.py
@@ -49,7 +49,9 @@ def inspire_citation(c): # download single INSPIRE citation
     f.close()
     bib = "@"+bib.split("@")[1].split('</pre>')[-2]
 
-    if bib.split("{")[1].split(',')[0] == c: # Check you got what you where looking for
+    if ( bib.split("{")[1].split(',')[0] == c or
+         re.split('eprint\s*=\s*"',bib)[-1].split('",')[0] == c 
+       ): # Check you got what you where looking for
         return bib
     else:
         return None


### PR DESCRIPTION
Dear Davide Gerosa,

This fix allows the citation 'c' in function inspire_citation in  fillbib.py to be an arXiv eprint numbe in the current (old) format 0912.3905 (hep-ph/0401138). It is safe even when 'bib' is an empty string

We can test this by using the program  as a module, for example:
```python
import fillbib
fillbib.inspire_citation("0912.3905")
```


