### PR TITLE
Avoid creating duplicated bibtex entries from iNSPIRE

### DIFF
--- a/fillbib.py
+++ b/fillbib.py
@@ -66,10 +66,11 @@ def inspire_citation(key,
         return None
     if not generate:
         bib = urllib.urlopen(data['hits']['hits'][0]['links']['bibtex']).read()
+        inspire_key = data['hits']['hits'][0]['metadata']['texkeys'][0]
         if sys.version_info.major >= 3:
-            return bib.decode()
+            return bib.decode().replace(inspire_key, key)
         else:
-            return bib
+            return bib.replace(inspire_key, key)
     metadata = data['hits']['hits'][0]['metadata']
 
     doctype = metadata["document_type"][0]
@@ -282,4 +283,7 @@ if __name__ == "__main__":
     parser_list.set_defaults(func=fillbib_list)
 
     args = parser.parse_args()
-    args.func(args)
+    try:
+        args.func(args)
+    except:
+        parser.print_usage()


### PR DESCRIPTION
iNSPIRE sometimes returns bibtex entries with a different key from the
one used to query the database. For example, searching for
"Monitor:2017mdv" returns a valid bibtex entry, but with key
"LIGOScientific:2017zic". This caused fillbib and bibtex to be confused.
This fix replaces the iNSPIRE key in the bibtex with the key used for
the search, so that the entry is correctly found by both bibtex and
fillbib.