### PR TITLE
Set doctype to article when generating the bibtex

### DIFF
--- a/fillbib.py
+++ b/fillbib.py
@@ -73,7 +73,7 @@ def inspire_citation(key,
             return bib.replace(inspire_key, key)
     metadata = data['hits']['hits'][0]['metadata']
 
-    doctype = metadata["document_type"][0]
+    doctype = "article" # metadata["document_type"][0]
 
     # BibTeX entry as a dictionary
     bibtex = {}
@@ -154,7 +154,7 @@ def inspire_citation(key,
     s = "@{}{{{}".format(doctype, key)
     for field, value in bibtex.items():
         s += ",\n    {} = \"{}\"".format(field, value)
-    s += "\n}"
+    s += "\n}\n"
 
     return s
 


### PR DESCRIPTION
The doctype returned by iNSPIRE is not compatible with bibtex. As a
workaround we set the doctype to "article" for everything.